### PR TITLE
Fix minor issues

### DIFF
--- a/HDF5/Dataset.pm
+++ b/HDF5/Dataset.pm
@@ -198,7 +198,6 @@ B<Usage:>
 );
 
 #   Mapping of PDL types to what types they are written to in the HDF5 file.
-my %PDLtoHDF5fileMapping;
 if ( isbigendian() ) {
   %PDLtoHDF5fileMapping = (
     $PDL::Types::PDL_SB => PDL::IO::HDF5::H5T_STD_I8BE(),

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -125,7 +125,6 @@ my $meta_merge = {
      'Andrew Benson <abenson AT obs.carnegiescience.edu>',
    ],
    'license'  => [ 'perl_5' ],
-   'version' => '0.73',
    'meta_spec' => {
       'version' => '2',
       'url'     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
@@ -155,7 +154,7 @@ my $meta_merge = {
       },
    },
    resources => {
-      license     => [ 'http://cpansearch.perl.org/src/CHM/PDL-IO-HDF5-0.73/COPYRIGHT' ],
+      license     => [ 'http://dev.perl.org/licenses/' ],
       homepage    => 'http://pdl.perl.org/',
       bugtracker  => {
          web    => 'https://github.com/PDLPorters/pdl-io-hdf5/issues',
@@ -199,4 +198,4 @@ WriteMakefile(
   'dist'         => { COMPRESS => 'gzip', SUFFIX => 'gz', PREOP => $preop },
 );
 
-sub MY::postamble { pdlpp_postamble($package); }	
+sub MY::postamble { pdlpp_postamble($package); }


### PR DESCRIPTION
Fixed two minor issues in the package
- `Dataset.pm` declares `%PDLtoHDF5fileMapping` as a local variable, i.e. `my %PDLtoHDF5fileMapping`. However, this variable was already declared as a local one to the package (via `our` statement) at the top of the file. This will cause users' scripts with a shebang like `#!/usr/bin/perl -w` to print warning messages like 
>"my" variable %PDLtoHDF5fileMapping masks earlier declaration in same scope at /usr/lib/x86_64-linux-gnu/perl5/5.30/PDL/IO/HDF5/Dataset.pm line 197.

-  Package version in `Makefile.PL` is not consistent with the one in `HDF5.pm`. Because of this inconsistency when the user installs the package via cpanm (i.e. `cpanm PDL::IO::HDF5@0.76`),  incorrect package version will be embedded in the log message, which is misleading.

> --> Working on PDL::IO::HDF5
> Fetching http://www.cpan.org/authors/id/E/ET/ETJ/PDL-IO-HDF5-0.76.tar.gz ... OK
> Configuring PDL-IO-HDF5-**0.73** ... OK
> Building and testing PDL-IO-HDF5-**0.73** ... 
> OK
> Successfully installed PDL-IO-HDF5-**0.73**
> 1 distribution installed
>
